### PR TITLE
Update hololens-rs4-preview.md

### DIFF
--- a/mixed-reality-docs/hololens-rs4-preview.md
+++ b/mixed-reality-docs/hololens-rs4-preview.md
@@ -199,9 +199,7 @@ You can download the setup package from [https://aka.ms/hololenspreviewdownload]
 
 ## Known issues in this preview
 
-* When upgrading to this preview build from a public build, any holograms previously placed in the world will be removed. 
-* We're also tracking an issue where internet pages will not load in Microsoft Edge after upgrading to this build. 
-* Some users have reported an issue with taking control of their Insider settings in this build.
+* Some users have reported an issue with Windows Insider Program settings on this build. If you encounter problems, please file a bug in Feedback Hub, and re-flash your device.
 
 ## Note for developers
 


### PR DESCRIPTION
Removed the first two release notes related to RS1 to RS4 upgrade because it currently requires a clean flash to test out the build.