### PR TITLE
add link back to core device portal APIs (per user feedback)

### DIFF
--- a/mixed-reality-docs/device-portal-api-reference.md
+++ b/mixed-reality-docs/device-portal-api-reference.md
@@ -530,3 +530,4 @@ Return data
 
 ## See also
 * [Using the Windows Device Portal](using-the-windows-device-portal.md)
+* [Device Portal core API reference (UWP)](https://docs.microsoft.com/windows/uwp/debug-test-perf/device-portal-api-core)


### PR DESCRIPTION
I own the topic that is linked to. We have a number of device portal topics (but for HoloLens APIs, we link back to this page), and it would be good to bridge the gap between these two similar sets of content.