### PR TITLE
Include "XR" to navigation path to "Holographic Emulation" option

### DIFF
--- a/mixed-reality-docs/holograms-100.md
+++ b/mixed-reality-docs/holograms-100.md
@@ -140,7 +140,7 @@ Now that we have created our cube, it is time to do a quick check in device. You
 1. On your HoloLens, install and run the [Holographic Remoting Player](holographic-remoting-player.md), available from the Windows Store. Launch the application on the device, and it will enter a waiting state and show the IP address of the device. Note down the IP.
 2. On your development PC, in Unity, open **File > Build Settings** window.
 3. Change **Platform** to **Universal Windows Platform** and click **Switch Platform**.
-4. Open **Window > Holographic Emulation**.
+4. Open **Window > XR > Holographic Emulation**.
 5. Change **Emulation Mode** from **None** to **Remote to Device**.
 6. In **Remote Machine**, enter the IP address of your HoloLens noted earlier.
 7. Click **Connect**.


### PR DESCRIPTION
In Section:[ For HoloLens use Unity Remoting](https://docs.microsoft.com/en-us/windows/mixed-reality/holograms-100#for-hololens-use-unity-remoting)

Step 4 should now be:
"4. Open **Window > XR > Holographic Emulation**."