### PR TITLE
Add a note about updating to IL2CPP

### DIFF
--- a/mixed-reality-docs/mrtk-porting-guide.md
+++ b/mixed-reality-docs/mrtk-porting-guide.md
@@ -13,14 +13,15 @@ keywords: Windows Mixed Reality, test, MRTK, MRTK version 2, HoloLens 2
 If you have an existing HoloLens app built in Unity, here is your best bet - start with current HoloLens (1st gen),  latest Visual Studio, Unity 2018.3.x, and MRTK version 2 Beta.
 MRTK version 2 is the new toolkit on top of Unity supporting both HoloLens (1st gen) and HoloLens 2, and where all of the new HoloLens 2 capabilities will be added, such as hand interactions and eye tracking.
 
-For more information on specific API differences between HTK/MRTK and MRTK version 2, see the porting guide on the <a href="https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Moving-your-project-from-HoloToolkit-2017-to-MixedRealityToolkit-v2" target="_blank">MRTK Version 2 wiki</a>.
+For more information on specific API differences between HTK/MRTK and MRTK version 2, see the porting guide on the [MRTK Version 2 wiki](https://github.com/Microsoft/MixedRealityToolkit-Unity/wiki/Moving-your-project-from-HoloToolkit-2017-to-MixedRealityToolkit-v2).
 
 
 ## Pre-work to do without a HoloLens 2 device
 
-* Move existing apps to Unity 2018.3 and verify it works with on HoloLens (1st gen)
+* Move existing apps to Unity 2018.3 and verify it works with on HoloLens (1st gen).
+* Move existing apps to [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) and verify it works with on HoloLens (1st gen).
 * In Visual Studio, try building for ARM, and assess if there are missing ARM libraries/dependencies.  Note: Unity 2018 supports ARM32.  You need Unity 2019.1 or later to use ARM64.
-* Move existing apps to MRTK version 2 and verify it works with on HoloLens (1st gen)
+* Move existing apps to MRTK version 2 and verify it works with on HoloLens (1st gen).
 
 We’ve found it easier to diagnose ARM build gaps prior to updating to MRTK version 2.<br>
 If the above three are error-free, then you are in a good place to get your app ported to HoloLens 2.


### PR DESCRIPTION
- MRTK v2 currently requires IL2CPP, so let people know they need to make this change in their projects.
- Also replace an html based link with a markdown based link.