### PR TITLE
Corrected quality level names

### DIFF
--- a/mixed-reality-docs/Configure-Unity-Project.md
+++ b/mixed-reality-docs/Configure-Unity-Project.md
@@ -49,7 +49,7 @@ Your app can now do basic holographic rendering and spatial input. To go further
 
 HoloLens has a mobile-class GPU. If your app is targeting HoloLens, you'll want the quality settings tuned for fastest performance to ensure we maintain full framerate:
 1. Select **Edit > Project Settings > Quality**
-2. Select the **dropdown** under the **Windows Store** logo and select **Fastest**. You'll know the setting is applied correctly when the box in the Windows Store column and **Fastest** row is green.
+2. Select the **dropdown** under the **Windows Store** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Windows Store column and **Very Low** row is green.
 
 ## Per-scene settings
 

--- a/mixed-reality-docs/holograms-100.md
+++ b/mixed-reality-docs/holograms-100.md
@@ -92,7 +92,7 @@ In this chapter, we will set some Unity project settings that help us target the
 
 Since maintaining high framerate on HoloLens is so important, we want the quality settings tuned for fastest performance. For more detailed performance information, [Performance recommendations for Unity](performance-recommendations-for-unity.md).
 1. Select **Edit > Project Settings > Quality**
-2. Select the **dropdown** under the **Windows Store** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Windows Store column and Fastest row is green.
+2. Select the **dropdown** under the **Windows Store** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Windows Store column and **Very Low** row is green.
 
 **For mixed reality applications targeted to occluded displays**, you can leave the quality settings to its default values.
 

--- a/mixed-reality-docs/holograms-210.md
+++ b/mixed-reality-docs/holograms-210.md
@@ -98,7 +98,7 @@ Finally, we'll update our quality settings to achieve a fast performance on Holo
 
 1. Go to **Edit > Project Settings > Quality**.
 2. Click on downward pointing arrow in the **Default** row under the Windows Store icon.
-3. Select **Fastest** for **Windows Store Apps**.
+3. Select **Very Low** for **Windows Store Apps**.
 
 ### Import project assets
 

--- a/mixed-reality-docs/holograms-230.md
+++ b/mixed-reality-docs/holograms-230.md
@@ -80,7 +80,7 @@ keywords: holotoolkit, mixedrealitytoolkit, mixedrealitytoolkit-unity, academy, 
     * Microphone
     * SpatialPerception
 * Go to **Edit > Project Settings > Quality**
-* In the **Inspector** panel, under the Windows Store icon, select the black drop-down arrow under the 'Default' row and change the default setting to **Fastest**.
+* In the **Inspector** panel, under the Windows Store icon, select the black drop-down arrow under the 'Default' row and change the default setting to **Very Low**.
 * Go to **Assets > Import Package > Custom Package**.
 * Navigate to the **...\HolographicAcademy-Holograms-230-SpatialMapping\Starting** folder.
 * Click on **Planetarium.unitypackage**.

--- a/mixed-reality-docs/recommended-settings-for-unity.md
+++ b/mixed-reality-docs/recommended-settings-for-unity.md
@@ -16,11 +16,11 @@ Unity provides a set of default options that are generally the average case for 
 
 ### Low quality settings
 
-It is important to modify the **Unity Quality settings** for your environment to **"fastest"**. This will help ensure your application is running performantly at the appropriate framerate. This is extremely significant for Hololens development. For development on immersive headsets, depending on the specs of the desktop powering the VR experience, one can still achieve framerate without the lowest quality parameters. 
+It is important to modify the **Unity Quality settings** for your environment to **Very Low**. This will help ensure your application is running performantly at the appropriate framerate. This is extremely significant for Hololens development. For development on immersive headsets, depending on the specs of the desktop powering the VR experience, one can still achieve framerate without the lowest quality parameters. 
 
 In Unity 2018 LTS+, the project's quality level can be set by:
 
-Under **Edit** > **Project Settings** > **Quality** > Set the **Default** by clicking on the downward arrow to the **Fastest** quality level
+Under **Edit** > **Project Settings** > **Quality** > Set the **Default** by clicking on the downward arrow to the **Very Low** quality level
 
 ### Lighting settings
 


### PR DESCRIPTION
Between Unity 2017 & Unity 2018, quality levels were renamed from "Fastest -> Fantastic" to "Very Low -> Ultra". Updated docs to reflect this change.

https://docs.unity3d.com/2017.4/Documentation/Manual/class-QualitySettings.html