### PR TITLE
Update MRTK Porting guide with more links & updated info

### DIFF
--- a/mixed-reality-docs/mrtk-porting-guide.md
+++ b/mixed-reality-docs/mrtk-porting-guide.md
@@ -27,9 +27,9 @@ It is **highly recommended** that, before beginning the porting process, develop
 
 ## Migrate project to latest version of Unity
 
-If you are using MRTK v2, then Unity 2018 LTS is the best long-term support path with no breaking changes in Unity or in MRTK. The recommended Unity build, per "Install the tools" is Unity 2018.3, which becomes the LTS release for Unity 2018. Also, the MRTK v2 always guarantees support for Unity 2018 LTS, but does not necessarily guarantee support for every iteration of Unity 2019.x. 
+If you are using [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), then [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) is the best long-term support path with no breaking changes in Unity or in MRTK. Also, the MRTK v2 always guarantees support for Unity 2018 LTS, but does not necessarily guarantee support for every iteration of Unity 2019.x. 
 
-To help clarify additional differences between Unity 2018.3.x and Unity 2019.1.x, the following outlines the trade-offs between these two versions. The primary difference between the two is the ability to compile for ARM64 in Unity 2019. 
+To help clarify additional differences between [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) and Unity 2019.1.x, the following outlines the trade-offs between these two versions. The primary difference between the two is the ability to compile for ARM64 in Unity 2019. 
 
 Developers should assess any [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) that currently exist in their project, and whether or not these DLLs can be built for ARM64. If a hard dependency plugin cannot be built for ARM64, then you will have to use Unity 2018 LTS.
 
@@ -43,7 +43,7 @@ Developers should assess any [plugin dependencies](https://docs.unity3d.com/Manu
 
 ## Update scene/project settings in Unity
 
-After updating to Unity 2018.3.x or Unity 2019+, it is recommended to update particular settings in Unity for optimal results on the device. These settings are outlined in detail under **[Recommended settings for Unity](Recommended-settings-for-Unity.md)**.
+After updating to [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) or Unity 2019+, it is recommended to update particular settings in Unity for optimal results on the device. These settings are outlined in detail under **[Recommended settings for Unity](Recommended-settings-for-Unity.md)**.
 
 It should be re-iterated that the [.NET scripting back-end](https://docs.unity3d.com/Manual/windowsstore-dotnet.html) is being deprecated in Unity 2018 and *removed* in Unity 2019. Dvelopers should strongly consider switching their project over to [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html). 
 
@@ -55,7 +55,7 @@ After addressing any breaking changes after moving to the updated Unity version,
 
 ## Compile dependencies/plugins for ARM processor
 
-HoloLens (1st Gen) executes applications on an x86 processor while the HoloLens 2 uses an ARM processor. Therfore, existing HoloLens applications need to be ported over to support ARM. As noted earlier, Unity 2018 supports compiling for ARM32 apps while Unity 2019.x supports compiling for ARM64 apps. Developing for ARM64 applications is generally preferred as there is a material difference in performance. However, this requires all [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) to also be built for ARM64. 
+HoloLens (1st Gen) executes applications on an x86 processor while the HoloLens 2 uses an ARM processor. Therfore, existing HoloLens applications need to be ported over to support ARM. As noted earlier, Unity 2018 LTS supports compiling for ARM32 apps while Unity 2019.x supports compiling for ARM64 apps. Developing for ARM64 applications is generally preferred as there is a material difference in performance. However, this requires all [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) to also be built for ARM64. 
 
 Review all DLL dependencies in your application. It is advisable to remove from your project any depencency that is no longer needed. For remaining plugins that are required, ingest the respective ARM32 or ARM64 binaries into your Unity project. 
 
@@ -63,37 +63,43 @@ After ingesting the relevant DLLs, build a Visual Studio solution from Unity, an
 
 ## Update to MRTK version 2
 
-MRTK Version 2 is the new toolkit on top of Unity that supports both HoloLens (1st gen) and HoloLens 2, and where all of the new HoloLens 2 capabilities have been added, such as hand interactions and eye tracking.
+[MRTK Version 2](https://github.com/microsoft/MixedRealityToolkit-Unity) is the new toolkit on top of Unity that supports both HoloLens (1st gen) and HoloLens 2, and where all of the new HoloLens 2 capabilities have been added, such as hand interactions and eye tracking.
+
+Please read the following for more information on using MRTK version 2:
+- [MRTK Landing Page](https://microsoft.github.io/MixedRealityToolkit-Unity/README.html)
+- [Getting started with MRTK](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)
+- [MRTK Hands](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/InputSystem/HandTracking.html)
+- [MRTK Eye Tracking](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/EyeTracking/EyeTracking_Main.html)
 
 ### Prepare for the migration
 
 Before ingesting the new [*.unitypackage files for MRTK v2](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases), it is recommended to take an inventory of **1) any custom-built code that integrates with MRTK v1** and **2) any custom-built code for input interactions or UX components**. The most common and prevalent conflict for a mixed reality developer ingesting MRTK v2 involves input and interactions. It is advised to begin reading and understanding the [MRTK v2 input model](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Overview.html).
 
-Finally, the new MRTK v2 has transitioned from a model of scripts and in-scene manager objects to a configuration and services provider architecture. This results in a cleaner scene hierarchy and architecture model but requires a learning curve for understanding the new configuration profiles. Thus, please read the [Mixed Reality Toolkit Configuration Guide](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html) to start becoming familiar with the important settings and profiles to adjust to the needs of your application. 
+Finally, the new [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity) has transitioned from a model of scripts and in-scene manager objects to a configuration and services provider architecture. This results in a cleaner scene hierarchy and architecture model but requires a learning curve for understanding the new configuration profiles. Thus, please read the [Mixed Reality Toolkit Configuration Guide](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html) to start becoming familiar with the important settings and profiles to adjust to the needs of your application. 
 
 ### Perform the migration
 
-After importing MRTK v2, your Unity project most likely has many compiler related errors. These are commonly due to the new namespace structure and new component names. Proceed to resolve these errors by modifying your scripts to the new namespaces and components. 
+After importing [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), your Unity project most likely has many compiler related errors. These are commonly due to the new namespace structure and new component names. Proceed to resolve these errors by modifying your scripts to the new namespaces and components. 
 
 For more information on specific API differences between HTK/MRTK and MRTK Version 2, see the porting guide on the [MRTK Version 2 wiki](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/HTKToMRTKPortingGuide.html).
 
 ### Best practices
 
-- Prefer use of the MRTK standard shader.
-- Work on one breaking change type at a time (ex: IFocusable to IMixedRealityFocusHandler).
+- Prefer use of the [MRTK standard shader](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_MRTKStandardShader.html).
+- Work on one breaking change type at a time (ex: IFocusable to [IMixedRealityFocusHandler](https://microsoft.github.io/MixedRealityToolkit-Unity/api/Microsoft.MixedReality.Toolkit.Input.IMixedRealityFocusHandler.html)).
 - Test after every change and use source control.
 - Use default MRTK UX (buttons, slates, etc) when possible.
 - Refrain from modifying MRTK files directly; create wrappers around MRTK components.
     - This protects against future MRTK ingestions and updates.
 - Review and explore sample scenes provided in the MRTK, especially *HandInteractionExamples.scene*.
 - Rebuild canvas-based UI with quads, colliders, and TextMeshPro text.
-- Set DepthLSR from SetFocusPlane; use a 16-bit depth buffer for better performance.
+- Enable [Depth Buffer Sharing](camera-in-unity.md#sharing-your-depth-buffers-with-windows) and/or [set focus point](focus-point-in-unity.md); use a 16-bit depth buffer for better performance. Ensure when rendering color, to also render depth. Unity generally does not write depth for transparent and text gameobjects. 
 - Set Single Pass Instanced Rendering Path.
-- Setup MRTK v2 profiles after port; turn off Teleport and Boundry services; generally only needed for VR.
+- Utilize the [Hololens 2 configuration profile for MRTK](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Profiles/Profiles.html#hololens-2-profile)
 
 ### Testing your application
 
-Now that HoloLens 2 components and capabilities are available in MRTK Version 2, as of [RC1](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.0.0-RC1), you can simulate hand interactions directly in Unity as well as develop with the new APIs for hand interactions and eye tracking. The HoloLens 2 device is required to create a satisfying user experience. Your are encouraged to start studying the documentation and tools for greaer understanding. MRTK v2 supports development on HoloLens (1st Gen), and traditional input models, such as select via air-tap can be tested on HoloLens (1st Gen). 
+Now that HoloLens 2 components and capabilities are available in MRTK Version 2, as of [RC1](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases/tag/v2.0.0-RC1), you can simulate hand interactions directly in Unity as well as develop with the new APIs for hand interactions and eye tracking. The HoloLens 2 device is required to create a satisfying user experience. Your are encouraged to start studying the documentation and tools for greaer understanding. [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity) supports development on HoloLens (1st Gen), and traditional input models, such as select via air-tap can be tested on HoloLens (1st Gen). 
 
 ## Updating interaction model for HoloLens 2
 
@@ -101,11 +107,9 @@ Once your your application is ported and prepped for HoloLens 2, you're ready to
 In HoloLens (1st Gen), your application likely has a gaze and commit interaction model with holograms relatively far away to fit into the field of view.
 
 Steps to update your applicaiton design to be best suited for HoloLens 2:
-1.	MRTK components: Per the pre-work, if you added MRTK v2, there are various components/scripts to leverage that have been designed and optimized for HoloLens 2.
+1.	MRTK components: Per the pre-work, if you added [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), there are various components/scripts to leverage that have been designed and optimized for HoloLens 2.
 
 2.	Interaction model: Consider updating your interaction model. For most scenarios, we recommend switching from gaze and commit to hands. With your holograms typically being out of arms reach, switching to hands results in far interaction pointing rays and grab gestures.
-Note: there are scenarios where a hands-free interaction model is required, such as a task worker holding tools. See [Hands free documentation]((https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-porting-guide).
-
 
 3.	Hologram placement: After switching to a hands interaction model, consider moving some holograms closer to directly interact with them with your hands using near interaction grab gestures. The types of holograms recommended to move closer to directly grab or interact are small target menus, controls, buttons, and smaller holograms that fit within the HoloLens 2 field of view when grabbing and inspecting the hologram.
 <br>
@@ -129,9 +133,9 @@ Every application and scenario is different, and we’ll continue to refine and 
 - The shader compiler on ARM runs during the first draw call after the shader has been loaded or something the shader relies on has changed, not at shader load time. The impact on framerate can be very noticeable, depending on how many shaders need to be compiled. This has various implications for how shaders should be handled, packaged, updated differently on HoloLens 2 vs HoloLens (1st Gen).
 
 ## See also
-* [Getting started with MRTK version 2](mrtk-getting-started.md)
-* [MRTK Version 2 HowTo](https://microsoft.github.io/MixedRealityToolkit-Unity/External/HowTo/README.html)
 * [Install the tools](install-the-tools.md)
+* [Getting started with MRTK version 2](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)
+* [HTK APIs to MRTK APIs](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/HTKToMRTKPortingGuide.html)
 * [Recommended settings for Unity](recommended-settings-for-unity.md)
 * [Understanding performance for Mixed Reality](understanding-performance-for-mixed-reality.md)
 


### PR DESCRIPTION
Realized there were no links to any MRTK articles really directly in this guide. Added some notes & links directly to MRTK specific doc pages. Fixed some broken links. Removed references to Unity 2018.3 in favor of Unity 2018 LTS.

Also removed this as the link just points to the same page, not exactly sure where else to point it for hands free 

"Note: there are scenarios where a hands-free interaction model is required, such as a task worker holding tools. See [Hands free documentation](https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-porting-guide)."