### PR TITLE
remove feature flag of using v2 cache

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -53,8 +53,5 @@
   },
   "docs_build_engine": {
     "name": "docfx_v3"
-  },
-  "feature_flags": {
-    "use_v2_github_user_cache": true
   }
 }


### PR DESCRIPTION
Feature flag `use_v2_github_user_cache` is only used during migrating to docfx v3, which can be removed now, it won't bring any impact to your content and publish result.