### PR TITLE
C109177: Escaping mock URLs

### DIFF
--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -49,7 +49,7 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 
 1. [Install the tools](install-the-tools.md) to make sure you have Visual Studio Update 1 with the Windows 10 developer tools installed on your PC. This enables USB connectivity.
 2. Connect your HoloLens to your PC with a micro-USB cable.
-3. From a web browser on your PC, go to [](http://127.0.0.1:10080).
+3. From a web browser on your PC, go to [http://127.0.0.1:10080](http://127.0.0.1:10080).
 
 ## Connecting to an emulator
 

--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -49,7 +49,7 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 
 1. [Install the tools](install-the-tools.md) to make sure you have Visual Studio Update 1 with the Windows 10 developer tools installed on your PC. This enables USB connectivity.
 2. Connect your HoloLens to your PC with a micro-USB cable.
-3. From a web browser on your PC, go to http://127.0.0.1:10080.
+3. From a web browser on your PC, go to http\://127.0.0.1:10080.
 
 ## Connecting to an emulator
 

--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -49,7 +49,7 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 
 1. [Install the tools](install-the-tools.md) to make sure you have Visual Studio Update 1 with the Windows 10 developer tools installed on your PC. This enables USB connectivity.
 2. Connect your HoloLens to your PC with a micro-USB cable.
-3. From a web browser on your PC, go to http\://127.0.0.1:10080.
+3. From a web browser on your PC, go to [](http://127.0.0.1:10080).
 
 ## Connecting to an emulator
 


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.
Description: All hyperlinks are mock hyperlinks and should not be rendered. Please consider adding a backslash on all hyperlinks to prevent link rendering