### PR TITLE
Clarify that "hands detected" on HoloLens 2

### DIFF
--- a/mixed-reality-docs/holograms-211.md
+++ b/mixed-reality-docs/holograms-211.md
@@ -116,7 +116,8 @@ If deploying to an immersive headset:
 * Subscribe to hand tracking events.
 * Use cursor feedback to show users when a hand is being tracked.
 
-> Note: On HoloLens 2 , hands detected fires whenever hands are visible (not just when a finger is pointing up).
+>[!NOTE]
+>On HoloLens 2 , hands detected fires whenever hands are visible (not just when a finger is pointing up).
 
 ### Instructions
 

--- a/mixed-reality-docs/holograms-211.md
+++ b/mixed-reality-docs/holograms-211.md
@@ -116,6 +116,8 @@ If deploying to an immersive headset:
 * Subscribe to hand tracking events.
 * Use cursor feedback to show users when a hand is being tracked.
 
+> Note: On HoloLens 2 , hands detected fires whenever hands are visible (not just when a finger is pointing up).
+
 ### Instructions
 
 * In the **Hierarchy** panel, expand the **InputManager** object.


### PR DESCRIPTION
Clarify that "hands detected" on HoloLens 2 fires whenever hands are visible, not just when index finger is pointing up. This is based on feedback from Andy Klein.