### PR TITLE
Update recommended-settings-for-unity.md

### DIFF
--- a/mixed-reality-docs/recommended-settings-for-unity.md
+++ b/mixed-reality-docs/recommended-settings-for-unity.md
@@ -62,9 +62,9 @@ Further, it is recommended to select **16-bit depth** under the **Depth Format**
 
 In order for the Windows Mixed Reality platform to optimize hologram stability, it relies on the depth buffer to be accurate and match any rendered holograms on screen. Thus, with depth buffer sharing on, it is important when rendering color, also render depth. In Unity, most Opaque or TransparentCutout materials will render depth by default but transparent and text objects will generally not render depth although this is shader dependent, etc. 
 
-If using the Mixed Reality Toolkit Standard shader, to render depth for transparent objects:
+If using the [Mixed Reality Toolkit Standard shader](https://github.com/microsoft/MixedRealityToolkit-Unity/blob/mrtk_release/Documentation/README_MRTKStandardShader.md), to render depth for transparent objects:
 1) Select the tranparent material that is using the MRTK Standard shader and open the Inspector editor window
-2) Set **Rendering Mode** to **Custom** then set **Mode** to **Transparent** and finally set **Depth Write** to **On**
+2) Select the **Fix Now** button within the depth buffer sharing warning. This can also be performed manually by setting the **Rendering Mode** to **Custom** then set **Mode** to **Transparent** and finally set **Depth Write** to **On**
 
 >[!NOTE]
 > Developers should beware of Z-fighting when changing these values along with the camera's near/far plane settings. Z-Fighting occurs when two gameobjects try to render to the same pixel and due to limitations in fidelity of the depth buffer (i.e z depth), Unity cannot discern which object is in front of the other. Developers will note a flickering between two game objects as they *fight* for the same z-depth value. This can be solved by switching to 24-bit depth format as there will be a larger range of values for each object to calculate upon for their z-depth from the camera.


### PR DESCRIPTION
Added a link to the MRTK Standard shader documentation and updated steps for fixing materials which do not work correctly with depth buffer sharing.