### PR TITLE
Update development.md to reflect page and section content.

### DIFF
--- a/mixed-reality-docs/development.md
+++ b/mixed-reality-docs/development.md
@@ -73,8 +73,11 @@ The HoloLens 2 tutorials are designed to help developers learn both techniques a
 
 <br>
 
-### [Example Unity scenes in MRTK](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_HandInteractionExamples.html)
+### [Hand interaction examples scene (MRTK) for Unity](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_HandInteractionExamples.html)
 The HandInteractionExamples.unity example scene contains various types of interactions and UI controls that highlight articulated hand input.
+
+### [Eye tracking examples (MRTK) for Unity](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/EyeTracking/EyeTracking_ExamplesOverview.html)
+This page covers how to get quickly started with using eye tracking in MRTK by building on our provided MRTK eye tracking examples.
 
 <br>
 


### PR DESCRIPTION
The page referenced "Example Unity scenes in MRTK" and linked to just the single scene for hand interaction examples. Changed the header to reflect the content on the page. Added the second example referenced in the left navigation on the section of the site referenced.