### PR TITLE
Update developer mode, redirect to HoloLens docs

### DIFF
--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -27,8 +27,8 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 ## Setting up HoloLens to use Windows Device Portal
 
 1. Power on your HoloLens and put on the device.
-2. Perform the [Start gesture](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage#start-gesture) for HoloLens2 or [Bloom](https://docs.microsoft.com/en-us/hololens/hololens1-basic-usage#open-the-start-menu-with-bloom) on HoloLens (1st Gen) to launch the main menu. 
-3. Gaze at the **Settings** tile and perform the [air-tap](https://docs.microsoft.com/en-us/hololens/hololens1-basic-usage#select-holograms-with-gaze-and-air-tap) gesture on HoloLens (1st Gen) or select it on HoloLens 2 by [touching it or using a Hand ray](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage). 
+2. Perform the [Start gesture](https://docs.microsoft.com/hololens/hololens2-basic-usage#start-gesture) for HoloLens2 or [Bloom](https://docs.microsoft.com/hololens/hololens1-basic-usage#open-the-start-menu-with-bloom) on HoloLens (1st Gen) to launch the main menu. 
+3. Gaze at the **Settings** tile and perform the [air-tap](https://docs.microsoft.com/hololens/hololens1-basic-usage#select-holograms-with-gaze-and-air-tap) gesture on HoloLens (1st Gen) or select it on HoloLens 2 by [touching it or using a Hand ray](https://docs.microsoft.com/hololens/hololens2-basic-usage). 
 4. Select the **Update** menu item.
 5. Select the **For developers** menu item.
 6. Enable **Developer Mode**.

--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -27,8 +27,8 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 ## Setting up HoloLens to use Windows Device Portal
 
 1. Power on your HoloLens and put on the device.
-2. Perform the [bloom](system-gesture.md#bloom) gesture to launch the main menu.
-3. Gaze at the **Settings** tile and perform the [air-tap](gaze-and-commit.md#composite-gestures) gesture. Perform a second air-tap to place the app in your environment. The Settings app will launch after you place it.
+2. Perform the [Start gesture](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage#start-gesture) for HoloLens2 or [Bloom](https://docs.microsoft.com/en-us/hololens/hololens1-basic-usage#open-the-start-menu-with-bloom) on HoloLens (1st Gen) to launch the main menu. 
+3. Gaze at the **Settings** tile and perform the [air-tap](https://docs.microsoft.com/en-us/hololens/hololens1-basic-usage#select-holograms-with-gaze-and-air-tap) gesture on HoloLens (1st Gen) or select it on HoloLens 2 by [touching it or using a Hand ray](https://docs.microsoft.com/en-us/hololens/hololens2-basic-usage). 
 4. Select the **Update** menu item.
 5. Select the **For developers** menu item.
 6. Enable **Developer Mode**.


### PR DESCRIPTION
Steps for enabling Developer mode were updated. 
Redirection to HoloLens docs. 
Several pieces of terminology updated.
Deleted obsolete step.
Pictures are still outdated but that can come later.
@scooley