### PR TITLE
Adding cable connection type to Device Portal doc

### DIFF
--- a/mixed-reality-docs/using-the-windows-device-portal.md
+++ b/mixed-reality-docs/using-the-windows-device-portal.md
@@ -48,7 +48,7 @@ This documentation is specifically about the Windows Device Portal for HoloLens.
 ## Connecting over USB
 
 1. [Install the tools](install-the-tools.md) to make sure you have Visual Studio Update 1 with the Windows 10 developer tools installed on your PC. This enables USB connectivity.
-2. Connect your HoloLens to your PC with a micro-USB cable.
+2. Connect your HoloLens to your PC with a micro-USB cable for HoloLens (1st Gen) or USB-C for HoloLens 2.
 3. From a web browser on your PC, go to [https://127.0.0.1:10080](https://127.0.0.1:10080).
 
 ## Connecting to an emulator


### PR DESCRIPTION
Adding USB-C mention to Device Portal Doc page since it still only listed cable for HL1.
@yannisle @scooley @jessemcculloch 
P.S. Screenshots of pages also need an update sometime in the future, but not critical.