### PR TITLE
Fix Lunar Module Not movind for Remote Users

### DIFF
--- a/mixed-reality-docs/mrlearning-sharing(photon)-ch4.md
+++ b/mixed-reality-docs/mrlearning-sharing(photon)-ch4.md
@@ -69,6 +69,12 @@ In this Tutorial, you'll learn how to share the movements of objects so that all
 11. From the Project panel in the Prefabs folder, drag the Table prefab into the "TableAnchor" child object that you just created.
 
     ![Module3Chapter4step8im](images/module3chapter4step8im.PNG)
+   
+12. Open the "Rocket Launcher_Complete Variant" prefab from Assets->Resources->Prefabs.
+
+13. Select the "LunarModule" GameObject and add the following two components: "Photon Transform View" and "Photon View"
+
+14. With the "LunarModule" GameObject still selected, drag the "Photon Transform View" component into the "Observed Components" slot in the "Photon View" component.
 
 ## Congratulations
 

--- a/mixed-reality-docs/mrlearning-sharing(photon)-ch4.md
+++ b/mixed-reality-docs/mrlearning-sharing(photon)-ch4.md
@@ -72,7 +72,7 @@ In this Tutorial, you'll learn how to share the movements of objects so that all
    
 12. Open the "Rocket Launcher_Complete Variant" prefab from Assets->Resources->Prefabs.
 
-13. Select the "LunarModule" GameObject and add the following two components: "Photon Transform View" and "Photon View"
+13. Select the "LunarModule" GameObject and add the following two components: "Photon Transform View" and "Photon View".
 
 14. With the "LunarModule" GameObject still selected, drag the "Photon Transform View" component into the "Observed Components" slot in the "Photon View" component.
 


### PR DESCRIPTION
This change add instructions to include a PhotonView and a PhotonTransformView so the LunarModule moves on remote when user drags it

After following the current set of instruction and importing the packages downloaded from https://docs.microsoft.com/en-us/windows/mixed-reality/mrlearning-sharing(photon)-ch2,  I did not see the lunar module moving on the remote end when I moved the lunar module. This is because there is no photon component that actually syncs the position, rotation of the LunarModule across the network. This change adds steps that instruct the user to add the PhotonView and PhotonTransformView components needed to make sure that the Lunar Module's position and rotation is synchronized across users.