### PR TITLE
Small tweak to Unity-HL2 getting started guide

### DIFF
--- a/mixed-reality-docs/mrlearning-base-ch1.md
+++ b/mixed-reality-docs/mrlearning-base-ch1.md
@@ -167,7 +167,8 @@ In the Import Unity Package window, click the **All** button to ensure all the a
 
 <!-- TODO: Consider adding info about configuring Unity for WMR vs MRTK, or removing WMR section -->
 
-In the Unity menu, select **Mixed Reality Toolkit** > **Utilities** > **Configure Unity Project** to open the MRTK Project Configurator window:
+After the package has been imported, the MRTK Project Configurator window should appear. If it does not, open it by 
+selecting **Mixed Reality Toolkit** > **Utilities** > **Configure Unity Project** in the Unity menu.
 
 ![mrlearning-base](images/mrlearning-base/tutorial1-section5-step1-1.png)
 


### PR DESCRIPTION
I've run through this twice now on two different computers, and both times with Unity 2019.2.x and MRTK 2.2.0, the MRTK Project Configurator has popped up automatically after importing the asset package. 

Obviously happy if you want to rewrite or restructure this, but figured I'd give you an easy one-line PR if that helps.