### PR TITLE
Add a note about how to fix missing dependencies

### DIFF
--- a/mixed-reality-docs/spatial-sound-in-unity.md
+++ b/mixed-reality-docs/spatial-sound-in-unity.md
@@ -31,6 +31,9 @@ Use [NuGet for Unity](https://github.com/GlitchEnzo/NuGetForUnity/releases/lates
 * Move the **Spatial Blend** slider to '1'
 * Ensure spatial audio is enabled on your developer workstation. Enable it by right-clicking on the volume icon in the task bar and making sure that Spatial Sound is set to something other than "off." To get the best representation of what you'll hear on HoloLens 2, choose **Windows Sonic for Headphones**.
 
+>[!NOTE]
+>If you get an error in Unity about not being able to load plugin Microsoft.SpatialAudio.Spatializer.Unity because one of its dependencies is missing, check that you have the latest version of the [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) installed on your PC.
+
 For more details, see:
 * [Microsoft spatializer GitHub repository](https://github.com/microsoft/spatialaudio-unity)
 * [Microsoft's spatializer tutorial](unity-spatial-audio-ch1.md)


### PR DESCRIPTION
The Microsoft.SpatialAudio.Spatializer.Unity plugin was built with the latest VC Runtime, and will not load if it is not installed on your development PC. Add a blurb about this requirement in case anyone doesn't have that one installed.