### PR TITLE
C197059: Leaving complete link in the same line instead of multiple lines

### DIFF
--- a/mixed-reality-docs/install-the-tools.md
+++ b/mixed-reality-docs/install-the-tools.md
@@ -39,8 +39,7 @@ We recommend installing the Unity game engine as the easiest way to get started 
 
 :::row:::
     :::column:::
-        <a href="https://unity3d.com/unity/qa/lts-releases?version=2018.4" target="_blank">![Unity](images/unity_logo.png)<br>
-        **Unity**</a><br>
+        <a href="https://unity3d.com/unity/qa/lts-releases?version=2018.4" target="_blank">![Unity](images/unity_logo.png)<br>**Unity**</a><br>
         We typically recommend the Unity LTS (Long Term Support) stream as the best version with which to start new projects, updating to its latest revision to pick up the latest stable fixes.<br>
         <br>
         The current recommendation is to use **Unity 2018.4.x**, which is the LTS build required for MRTK v2 below.<br>
@@ -49,15 +48,13 @@ We recommend installing the Unity game engine as the easiest way to get started 
         <br>
         See the [Unity development overview](unity-development-overview.md) to get started with Unity development for HoloLens 2 or Windows Mixed Reality immersive headsets.<br>
         <br>
-        <a href="https://github.com/Microsoft/MixedRealityToolkit-Unity/releases" target="_blank">![MRTK](images/final_mrtk-small_logo.png)<br>
-        **Mixed Reality Toolkit (MRTK)**</a><br>
+        <a href="https://github.com/Microsoft/MixedRealityToolkit-Unity/releases" target="_blank">![MRTK](images/final_mrtk-small_logo.png)<br>**Mixed Reality Toolkit (MRTK)**</a><br>
         Mixed Reality Toolkit (MRTK) v2 for Unity is an open source cross-platform development kit for mixed reality applications.<br>
         <br>
         MRTK v2 is intended to accelerate development of applications targeting Microsoft HoloLens, Windows Mixed Reality immersive (VR) headsets, and the OpenVR platform. The project is aimed at reducing the barriers to entry in creating mixed reality applications and contributing back to the community as things evolve.
     :::column-end:::
     :::column:::
-        <a href="https://docs.unrealengine.com//GettingStarted/Installation/index.html" target="_blank">![Unreal](images/Unreal_logo.png)<br>
-        **Unreal**</a><br>
+        <a href="https://docs.unrealengine.com//GettingStarted/Installation/index.html" target="_blank">![Unreal](images/Unreal_logo.png)<br>**Unreal**</a><br>
         Unreal Engine 4 is a powerful, open source creation engine with full support for mixed reality in both C++ and Blueprints.<br>
         <br>
         HoloLens support for Unreal Engine 4.24 is currently in beta.<br>


### PR DESCRIPTION
Localization team has reported source content issue that causes localized version to have broken/different format compared to en-us version.  
Description: Link divided in two lines is breaking display in localized pages.