### PR TITLE
Update default mixed reality capture video/audio effect property values for the June 2020 update

### DIFF
--- a/mixed-reality-docs/mixed-reality-capture-for-developers.md
+++ b/mixed-reality-docs/mixed-reality-capture-for-developers.md
@@ -229,15 +229,23 @@ MRC Video Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureVideoEf
 |  BlankOnProtectedContent  |  boolean  |  FALSE  |  Flag to enable or disable returning an empty frame if there is a 2d UWP app showing protected content. If this flag is false and a 2d UWP app is showing protected content, the 2d UWP app will be replaced by a protected content texture in both the headset and in the mixed reality capture. |
 |  ShowHiddenMesh  |  boolean  |  FALSE  |  Flag to enable or disable showing the holographic camera's hidden area mesh and neighboring content. |
 | OutputSize | Size | 0, 0 | Set the desired output size after cropping for video stabilization. A default crop size is chosen if 0 or an invalid output size is specified. |
-| PreferredHologramPerspective | UINT32 | 0 (Display) | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it) |
+| PreferredHologramPerspective | UINT32 | 1 (PhotoVideoCamera) | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it). Only supported on HoloLens 2 |
+
+>[!NOTE]
+> The default value of **PreferredHologramPerspective** was **0 (Display)** prior to the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 
 MRC Audio Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureAudioEffect**)
 
 | Property Name | Type | Default Value | Description |
 |----------|----------|----------|----------|
 | MixerMode | UINT32 | 2 (Mic and System audio) | Enum used to indicate which audio sources should be used: 0 (Mic audio only), 1 (System audio only), 2 (Mic and System audio) |
-| LoopbackGain | float | 1.0 | Gain to apply to system audio volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
-| MicrophoneGain | float | 1.0 | Gain to apply to mic volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
+| LoopbackGain | float | Configured via Windows Device Portal | Gain to apply to system audio volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
+| MicrophoneGain | float | Configured via Windows Device Portal | Gain to apply to mic volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
+
+>[!NOTE]
+> The default values of **LoopbackGain** and **MicrophoneGain** are configured via Windows Device Portal's [Mixed Reality Capture page](using-the-windows-device-portal.md#mixed-reality-capture). They default to **1.0**, but can be set to any value between **0.0** and **5.0**.
+>
+> Using Windows Device Portal to configure the default gain values was added with the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 
 ### Simultaneous MRC limitations
 

--- a/mixed-reality-docs/mixed-reality-capture-for-developers.md
+++ b/mixed-reality-docs/mixed-reality-capture-for-developers.md
@@ -229,10 +229,10 @@ MRC Video Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureVideoEf
 |  BlankOnProtectedContent  |  boolean  |  FALSE  |  Flag to enable or disable returning an empty frame if there is a 2d UWP app showing protected content. If this flag is false and a 2d UWP app is showing protected content, the 2d UWP app will be replaced by a protected content texture in both the headset and in the mixed reality capture. |
 |  ShowHiddenMesh  |  boolean  |  FALSE  |  Flag to enable or disable showing the holographic camera's hidden area mesh and neighboring content. |
 | OutputSize | Size | 0, 0 | Set the desired output size after cropping for video stabilization. A default crop size is chosen if 0 or an invalid output size is specified. |
-| PreferredHologramPerspective | UINT32 | Configured via Windows Device Portal | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it). Only supported on HoloLens 2 |
+| PreferredHologramPerspective | UINT32 | **Render from Camera** setting in the Windows Device Portal | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it). Only supported on HoloLens 2 |
 
 >[!NOTE]
-> The default value of **PreferredHologramPerspective** is configured via Windows Device Portal [Mixed Reality Capture page's](using-the-windows-device-portal.md#mixed-reality-capture) **Render from Camera** setting. It defaults to **1 (PhotoVideoCamera)**, but can be unchecked to set it to **0 (Display)**.
+> You can change the default value of **PreferredHologramPerspective** in the Windows Device Portal by going to the [Mixed Reality Capture page](using-the-windows-device-portal.md#mixed-reality-capture) and unchecking **Render from Camera**. The setting defaults to **1 (PhotoVideoCamera)**, but can be unchecked to set it to **0 (Display)**.
 >
 > The default value of **PreferredHologramPerspective** was **0 (Display)** prior to the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 
@@ -241,11 +241,11 @@ MRC Audio Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureAudioEf
 | Property Name | Type | Default Value | Description |
 |----------|----------|----------|----------|
 | MixerMode | UINT32 | 2 (Mic and System audio) | Enum used to indicate which audio sources should be used: 0 (Mic audio only), 1 (System audio only), 2 (Mic and System audio) |
-| LoopbackGain | float | Configured via Windows Device Portal | Gain to apply to system audio volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
-| MicrophoneGain | float | Configured via Windows Device Portal | Gain to apply to mic volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
+| LoopbackGain | float | **App Audio Gain** setting in the Windows Device Portal | Gain to apply to system audio volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
+| MicrophoneGain | float | **Mic Audio Gain** setting in the Windows Device Portal | Gain to apply to mic volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
 
 >[!NOTE]
-> The default values of **LoopbackGain** and **MicrophoneGain** are configured via Windows Device Portal's [Mixed Reality Capture page's](using-the-windows-device-portal.md#mixed-reality-capture) **App Audio Gain** and **Mic Audio Gain** settings. They default to **1.0**, but can be set to any value between **0.0** and **5.0**.
+> You can change the default value of **LoopbackGain** or **MicrophoneGain** in the Windows Device Portal by going to the [Mixed Reality Capture page](using-the-windows-device-portal.md#mixed-reality-capture) and adjusting the slider next to their respective settings. Both settings default to **1.0**, but can be set to any value between **0.0** and **5.0**.
 >
 > Using Windows Device Portal to configure the default gain values was added with the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 

--- a/mixed-reality-docs/mixed-reality-capture-for-developers.md
+++ b/mixed-reality-docs/mixed-reality-capture-for-developers.md
@@ -229,9 +229,11 @@ MRC Video Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureVideoEf
 |  BlankOnProtectedContent  |  boolean  |  FALSE  |  Flag to enable or disable returning an empty frame if there is a 2d UWP app showing protected content. If this flag is false and a 2d UWP app is showing protected content, the 2d UWP app will be replaced by a protected content texture in both the headset and in the mixed reality capture. |
 |  ShowHiddenMesh  |  boolean  |  FALSE  |  Flag to enable or disable showing the holographic camera's hidden area mesh and neighboring content. |
 | OutputSize | Size | 0, 0 | Set the desired output size after cropping for video stabilization. A default crop size is chosen if 0 or an invalid output size is specified. |
-| PreferredHologramPerspective | UINT32 | 1 (PhotoVideoCamera) | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it). Only supported on HoloLens 2 |
+| PreferredHologramPerspective | UINT32 | Configured via Windows Device Portal | Enum used to indicate which holographic camera view configuration should be captured: 0 (Display) means that the app won't be asked to render from the photo/video camera, 1 (PhotoVideoCamera) will ask the app to render from the photo/video camera (if the app supports it). Only supported on HoloLens 2 |
 
 >[!NOTE]
+> The default value of **PreferredHologramPerspective** is configured via Windows Device Portal [Mixed Reality Capture page's](using-the-windows-device-portal.md#mixed-reality-capture) **Render from Camera** setting. It defaults to **1 (PhotoVideoCamera)**, but can be unchecked to set it to **0 (Display)**.
+>
 > The default value of **PreferredHologramPerspective** was **0 (Display)** prior to the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 
 MRC Audio Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureAudioEffect**)
@@ -243,7 +245,7 @@ MRC Audio Effect (**Windows.Media.MixedRealityCapture.MixedRealityCaptureAudioEf
 | MicrophoneGain | float | Configured via Windows Device Portal | Gain to apply to mic volume. Ranges from 0.0 to 5.0. Only supported on HoloLens 2 |
 
 >[!NOTE]
-> The default values of **LoopbackGain** and **MicrophoneGain** are configured via Windows Device Portal's [Mixed Reality Capture page](using-the-windows-device-portal.md#mixed-reality-capture). They default to **1.0**, but can be set to any value between **0.0** and **5.0**.
+> The default values of **LoopbackGain** and **MicrophoneGain** are configured via Windows Device Portal's [Mixed Reality Capture page's](using-the-windows-device-portal.md#mixed-reality-capture) **App Audio Gain** and **Mic Audio Gain** settings. They default to **1.0**, but can be set to any value between **0.0** and **5.0**.
 >
 > Using Windows Device Portal to configure the default gain values was added with the June 2020 update (Windows Holographic, version 2004 build 19041.1106 and Windows Holographic, version 1903 build 18362.1064).
 


### PR DESCRIPTION
The June 2020 update changed a few default values, and this is updating the documentation to match the new values.

I put a note with the version info, but let me know if it is necessary (since both 1903 and 2004 are getting the change with the June 2020 update).