### PR TITLE
Update some deprecated .NET backend references

### DIFF
--- a/mixed-reality-docs/holograms-100.md
+++ b/mixed-reality-docs/holograms-100.md
@@ -88,7 +88,7 @@ Finally, let us save our progress so far. To save the scene changes, select **Fi
 
 >[!VIDEO https://www.youtube.com/embed/ItRoiXccC0g]
 
-In this chapter, we will set some Unity project settings that help us target the Windows Holographic SDK for development. We will also set some quality settings for our application. Finally, we will ensure our build targets are set to Windows Store.
+In this chapter, we will set some Unity project settings that help us target the Windows Holographic SDK for development. We will also set some quality settings for our application. Finally, we will ensure our build targets are set to Universal Windows Platform.
 
 ### Unity performance and quality settings
 
@@ -99,7 +99,6 @@ In this chapter, we will set some Unity project settings that help us target the
 Since maintaining high framerate on HoloLens is so important, we want the quality settings tuned for fastest performance. For more detailed performance information, [Performance recommendations for Unity](performance-recommendations-for-unity.md).
 
 1. Select **Edit > Project Settings > Quality**
-2. Select the **dropdown** under the **Windows Store** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Windows Store column and **Very Low** row is green.
 2. Select the **dropdown** under the **Universal Windows Platform** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Universal Windows Platform column and **Very Low** row is green.
 
 **For mixed reality applications targeted to occluded displays**, you can leave the quality settings to its default values.
@@ -113,13 +112,13 @@ Since maintaining high framerate on HoloLens is so important, we want the qualit
 We need to let Unity know that the app we are trying to export should create an [immersive view](app-views.md) instead of a 2D view. We do this by enabling Virtual Reality support on Unity targeting the Windows 10 SDK.
 
 1. Go to **Edit > Project Settings > Player**.
-2. In the **Inspector Panel** for Player Settings, select the **Windows Store** icon.
+2. In the **Inspector Panel** for Player Settings, select the **Universal Windows Platform** icon.
 3. Expand the **XR Settings** group.
 4. In the **Rendering** section, check the **Virtual Reality Supported** checkbox to add a new **Virtual Reality SDKs** list.
 5. Verify that **Windows Mixed Reality** appears in the list. If not, select the **+** button at the bottom of the list and choose **Windows Mixed Reality**.
 
 >[!NOTE]
->If you do not see the **Windows Store** icon, double check to make sure you selected the Windows Store .NET Scripting Backend prior to installation. If not, you may need to reinstall Unity with the correct Windows installation.
+>If you do not see the **Universal Windows Platform** icon, double check to make sure you selected Universal Windows Platform Build Support during installation. If not, you may need to reinstall Unity with the correct Windows installation.
 
 Awesome job on getting all the project settings applied. Next, let us add a hologram!
 

--- a/mixed-reality-docs/holograms-100.md
+++ b/mixed-reality-docs/holograms-100.md
@@ -8,12 +8,10 @@ ms.topic: article
 keywords: mixed reality, Windows Mixed Reality, HoloLens, immersive, vr, mr, get started, hologram, academy, tutorial
 ---
 
->[!NOTE]
->The Mixed Reality Academy tutorials were designed with HoloLens (1st gen) and Mixed Reality Immersive Headsets in mind.  As such, we feel it is important to leave these tutorials in place for developers who are still looking for guidance in developing for those devices.  These tutorials will **_not_** be updated with the latest toolsets or interactions being used for HoloLens 2.  They will be maintained to continue working on the supported devices. [A new series of tutorials](mrlearning-base.md) has been posted for HoloLens 2.
-
-<br>
-
 # MR Basics 100: Getting started with Unity
+
+>[!IMPORTANT]
+>The Mixed Reality Academy tutorials were designed with HoloLens (1st gen) and Mixed Reality Immersive Headsets in mind.  As such, we feel it is important to leave these tutorials in place for developers who are still looking for guidance in developing for those devices.  These tutorials will **_not_** be updated with the latest toolsets or interactions being used for HoloLens 2.  They will be maintained to continue working on the supported devices. [A new series of tutorials](mrlearning-base.md) has been posted for HoloLens 2.
 
 This tutorial will walk you through creating a basic mixed reality app built with Unity.
 

--- a/mixed-reality-docs/holograms-100.md
+++ b/mixed-reality-docs/holograms-100.md
@@ -100,6 +100,7 @@ Since maintaining high framerate on HoloLens is so important, we want the qualit
 
 1. Select **Edit > Project Settings > Quality**
 2. Select the **dropdown** under the **Windows Store** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Windows Store column and **Very Low** row is green.
+2. Select the **dropdown** under the **Universal Windows Platform** logo and select **Very Low**. You'll know the setting is applied correctly when the box in the Universal Windows Platform column and **Very Low** row is green.
 
 **For mixed reality applications targeted to occluded displays**, you can leave the quality settings to its default values.
 
@@ -119,14 +120,6 @@ We need to let Unity know that the app we are trying to export should create an 
 
 >[!NOTE]
 >If you do not see the **Windows Store** icon, double check to make sure you selected the Windows Store .NET Scripting Backend prior to installation. If not, you may need to reinstall Unity with the correct Windows installation.
-
-**Verify .NET Configuration**
-
-![Verify .NET Configuration](images/configoptions-375px.png)
-
-1. Go to **Edit > Project Settings > Player** (you may still have this up from the previous step).
-2. In the **Inspector Panel** for Player Settings, select the **Windows Store** icon.
-3. In the **Other Settings** Configuration section, make sure that **Scripting Backend** is set to **.NET**
 
 Awesome job on getting all the project settings applied. Next, let us add a hologram!
 
@@ -181,20 +174,19 @@ We are now ready to compile our project to Visual Studio and deploy to our targe
 
 ### Export to the Visual Studio solution
 
-1.  Open **File > Build Settings** window.
-2.  Click **Add Open Scenes** to add the scene.
-3.  Change **Platform** to **Universal Windows Platform** and click **Switch Platform**.
-4.  In **Windows Store** settings ensure, **SDK** is **Universal 10**.
-5.  For Target device, leave to **Any Device** for occluded displays or switch to **HoloLens**.
-6.  **UWP Build Type** should be **D3D**.
-7.  **UWP SDK** could be left at **Latest installed**.
-8.  Check **Unity C# Projects** under Debugging.
-9.  Click **Build**.
-10. In the file explorer, click **New Folder** and name the folder **"App"**.
-11. With the **App** folder selected, click the **Select Folder** button.
-12. When Unity is done building, a Windows File Explorer window will appear.
-13. Open the **App** folder in file explorer.
-14. Open the generated Visual Studio solution (MixedRealityIntroduction.sln in this example)
+1. Open **File > Build Settings** window.
+1. Click **Add Open Scenes** to add the scene.
+1. Change **Platform** to **Universal Windows Platform** and click **Switch Platform**.
+1. In **Universal Windows Platform** settings, ensure **SDK** is **Universal 10**.
+1. For Target device, leave to **Any Device** for occluded displays or switch to **HoloLens**.
+1. **UWP Build Type** should be **D3D**.
+1. **UWP SDK** could be left at **Latest installed**.
+1. Click **Build**.
+1. In the file explorer, click **New Folder** and name the folder **"App"**.
+1. With the **App** folder selected, click the **Select Folder** button.
+1. When Unity is done building, a Windows File Explorer window will appear.
+1. Open the **App** folder in file explorer.
+1. Open the generated Visual Studio solution (MixedRealityIntroduction.sln in this example)
 
 ### Compile the Visual Studio solution
 

--- a/mixed-reality-docs/mrtk-porting-guide.md
+++ b/mixed-reality-docs/mrtk-porting-guide.md
@@ -31,12 +31,11 @@ It is **highly recommended** that, before beginning the porting process, develop
 
 ## Migrate project to the latest version of Unity
 
-If you are using [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) is the best long-term support path with no breaking changes in Unity or in MRTK. Also, the MRTK v2 always guarantees support for Unity 2018 LTS, but does not necessarily guarantee support for every iteration of Unity 2019.x. 
+If you are using [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) is the best long-term support path with no breaking changes in Unity or in MRTK. Also, the MRTK v2 always guarantees support for Unity 2018 LTS, but does not necessarily guarantee support for every iteration of Unity 2019.x.
 
-To help clarify additional differences between [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) and Unity 2019.x, the following outlines the trade-offs between these two versions. The primary difference between the two is the ability to compile for ARM64 in Unity 2019. 
+To help clarify additional differences between [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) and Unity 2019.x, the following outlines the trade-offs between these two versions. The primary difference between the two is the ability to compile for ARM64 in Unity 2019.
 
-Developers should assess any [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) that currently exist in their project, and determine whether or not these DLLs can be built for ARM64. If a hard dependency plugin cannot be built for ARM64, you need to use Unity 2018 LTS.
-
+Developers should assess any [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) that currently exist in their project, and determine whether or not these DLLs can be built for ARM64. If a hard dependency plugin cannot be built for ARM64, you may need to continue building your app for ARM.
 
 | Unity 2018 LTS | Unity 2019.x |
 |----------|-------------------|
@@ -49,19 +48,19 @@ Developers should assess any [plugin dependencies](https://docs.unity3d.com/Manu
 
 After updating to [Unity 2018 LTS](https://unity3d.com/unity/qa/lts-releases) or Unity 2019+, it is recommended to update particular settings in Unity for optimal results on the device. These settings are outlined in detail under **[Recommended settings for Unity](Recommended-settings-for-Unity.md)**.
 
-It should be reiterated that the [.NET scripting back-end](https://docs.unity3d.com/Manual/windowsstore-dotnet.html) is being deprecated in Unity 2018 and *removed* in Unity 2019. Developers should strongly consider switching their project to [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html). 
+It should be reiterated that the [.NET scripting back-end](https://docs.unity3d.com/Manual/windowsstore-dotnet.html) is being deprecated in Unity 2018 and *removed* in Unity 2019. Developers should strongly consider switching their project to [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html).
 
 > [!NOTE]
 > IL2CPP scripting back-end can cause longer build times from Unity to Visual Studio, and developers should set up their developer machine for [optimizing IL2CPP build times](https://docs.unity3d.com/Manual/IL2CPP-OptimizingBuildTimes.html).
 > It might also be beneficial to set up a [cache server](https://docs.unity3d.com/Manual/CacheServer.html), especially for Unity projects with a large amount of assets (excluding script files) or constantly changing scenes and assets. When opening a project, Unity stores qualifying assets into an internal cache format on the developer machine. Items must be re-imported and re-processed when modified. This process can be done once and saved in a cache server and consequently shared with other developers to save time, as opposed to every developer processing the re-import of new changes locally.
 
-After addressing any breaking changes after moving to the updated Unity version, developers should build and test their current applications on HoloLens (1st gen). This is a good time to create and save a commit into source control. 
+After addressing any breaking changes after moving to the updated Unity version, developers should build and test their current applications on HoloLens (1st gen). This is a good time to create and save a commit into source control.
 
 ## Compile dependencies/plugins for ARM processor
 
-HoloLens (1st gen) executes applications on an x86 processor while the HoloLens 2 uses an ARM processor. Therefore, existing HoloLens applications need to be ported over to support ARM. As noted earlier, Unity 2018 LTS supports compiling ARM32 apps while Unity 2019.x supports compiling ARM32 and ARM64 apps. Developing for ARM64 applications is generally preferred, as there is a material difference in performance. However, this requires all [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) to also be built for ARM64. 
+HoloLens (1st gen) executes applications on an x86 processor while the HoloLens 2 uses an ARM processor. Therefore, existing HoloLens applications need to be ported over to support ARM. As noted earlier, Unity 2018 LTS supports compiling ARM32 apps while Unity 2019.x supports compiling ARM32 and ARM64 apps. Developing for ARM64 applications is generally preferred, as there is a material difference in performance. However, this requires all [plugin dependencies](https://docs.unity3d.com/Manual/Plugins.html) to also be built for ARM64.
 
-Review all DLL dependencies in your application. It is advisable to remove any dependency that is no longer needed from your project. For remaining plugins that are required, ingest the respective ARM32 or ARM64 binaries into your Unity project. 
+Review all DLL dependencies in your application. It is advisable to remove any dependency that is no longer needed from your project. For remaining plugins that are required, ingest the respective ARM32 or ARM64 binaries into your Unity project.
 
 After ingesting the relevant DLLs, build a Visual Studio solution from Unity and then compile an AppX for ARM in Visual Studio to test that your application can be built for ARM processors. It is advised to save the application as a commit in your source control solution.
 
@@ -70,6 +69,7 @@ After ingesting the relevant DLLs, build a Visual Studio solution from Unity and
 [MRTK Version 2](https://github.com/microsoft/MixedRealityToolkit-Unity) is the new toolkit on top of Unity that supports both HoloLens (1st gen) and HoloLens 2. It is also where all the new HoloLens 2 capabilities have been added, such as hand interactions and eye tracking.
 
 Please read the following for more information on using MRTK version 2:
+
 - [MRTK Landing Page](https://microsoft.github.io/MixedRealityToolkit-Unity/README.html)
 - [Getting started with MRTK](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/GettingStartedWithTheMRTK.html)
 - [MRTK Hands](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/HandTracking.html)
@@ -79,11 +79,11 @@ Please read the following for more information on using MRTK version 2:
 
 Before ingesting the new [*.unitypackage files for MRTK v2](https://github.com/Microsoft/MixedRealityToolkit-Unity/releases), it is recommended to take an inventory of **1) any custom-built code that integrates with MRTK v1** and **2) any custom-built code for input interactions or UX components**. The most common and prevalent conflict for a mixed reality developer ingesting MRTK v2 involves input and interactions. It is advised to begin reading and understanding the [MRTK v2 input model](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/Input/Overview.html).
 
-Finally, the new [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity) has transitioned from a model of scripts and in-scene manager objects to a configuration and services provider architecture. This results in a cleaner scene hierarchy and architecture model, but requires a learning curve for understanding the new configuration profiles. Thus, please read the [Mixed Reality Toolkit Configuration Guide](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html) to start becoming familiar with the important settings and profiles to adjust to the needs of your application. 
+Finally, the new [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity) has transitioned from a model of scripts and in-scene manager objects to a configuration and services provider architecture. This results in a cleaner scene hierarchy and architecture model, but requires a learning curve for understanding the new configuration profiles. Thus, please read the [Mixed Reality Toolkit Configuration Guide](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/MixedRealityConfigurationGuide.html) to start becoming familiar with the important settings and profiles to adjust to the needs of your application.
 
 ### Perform the migration
 
-After importing [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), your Unity project most likely has many compiler related errors. These are commonly due to the new namespace structure and new component names. Proceed to resolve these errors by modifying your scripts to the new namespaces and components. 
+After importing [MRTK v2](https://github.com/microsoft/MixedRealityToolkit-Unity), your Unity project most likely has many compiler related errors. These are commonly due to the new namespace structure and new component names. Proceed to resolve these errors by modifying your scripts to the new namespaces and components.
 
 For information on the specific API differences between HTK/MRTK and MRTK v2, see the porting guide on the [MRTK Version 2 wiki](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/HTKToMRTKPortingGuide.html).
 

--- a/mixed-reality-docs/porting-guides.md
+++ b/mixed-reality-docs/porting-guides.md
@@ -67,9 +67,10 @@ With any Unity update, there is a good chance that you need to update one or mor
 ### Unity step 4: Target your application to run on Universal Windows Platform (UWP)
 
 After installing the tools, you need to get your app running as a Universal Windows app.
+
 * Follow the [detailed step by step walk through](https://unity3d.com/partners/microsoft/porting-guides) provided by Unity. Please note that you should stay on the latest LTS release (any 20xx.4 release) for Windows MR.
 * For more UWP development resources, take a look at the [Windows 10 game development guide](https://docs.microsoft.com/windows/uwp/gaming/e2e).
-* Please note that Unity continues to improve IL2CPP support; IL2CPP makes some UWP ports significantly easier. If you are currently targeting the .Net scripting backend, you should consider converting to leverage the IL2CPP backend instead.
+* Please note that Unity continues to improve IL2CPP support; IL2CPP makes some UWP ports significantly easier. If you are currently targeting the .NET scripting backend, you should consider converting to leverage the IL2CPP backend instead.
 
 Note: If your application has any dependencies on device specific services, such as match making from Steam, you will need to disable them at this step. At a later time, you can hook up to the equivalent services that Windows provides.
 

--- a/mixed-reality-docs/recommended-settings-for-unity.md
+++ b/mixed-reality-docs/recommended-settings-for-unity.md
@@ -80,7 +80,7 @@ If using the [Mixed Reality Toolkit Standard shader](https://github.com/microsof
 
 ### Building for IL2CPP
 
-Unity has deprecated support for the .NET scripting backend and thus recommends that developers utilize **IL2CPP** for their UWP visual studio builds. Although this brings various advantages, building your visual studio solution from Unity for **Il2CPP** can be significantly slower than the old .NET method. Thus, it is highly recommended to follow best practices for building **IL2CPP** to save on development iteration time.
+Unity has deprecated support for the .NET scripting backend and thus recommends that developers utilize **IL2CPP** for their UWP visual studio builds. Although this brings various advantages, building your visual studio solution from Unity for **IL2CPP** can be significantly slower than the old .NET method. Thus, it is highly recommended to follow best practices for building **IL2CPP** to save on development iteration time.
 
 1) Leverage incremental building by building your project to the same directory every time, re-using the pre-built files there
 2) Disable anti-malware software scans for your project & build folders


### PR DESCRIPTION
* Updated some stale Windows Store build type references to UWP
* Removed a section on configuring the backend to .NET vs IL2CPP.

Fixes #490 