### PR TITLE
Fix typo in HolographicViewConfiguration code sample

### DIFF
--- a/mixed-reality-docs/mixed-reality-capture-for-developers.md
+++ b/mixed-reality-docs/mixed-reality-capture-for-developers.md
@@ -61,10 +61,10 @@ There are three steps to enable rendering from the PV camera:
 To opt-in to rendering from the PV Camera, an app simply enables the PhotoVideoCamera's [HolographicViewConfiguration](https://docs.microsoft.com/uwp/api/Windows.Graphics.Holographic.HolographicViewConfiguration):
 ```csharp
 var display = Windows.Graphics.Holographic.HolographicDisplay.GetDefault();
-var view = display.TryGetViewConfiguration(Windows.Graphics.Holographic.HolographicViewConfiguration.PhotoVideoCamera);
+var view = display.TryGetViewConfiguration(Windows.Graphics.Holographic.HolographicViewConfigurationKind.PhotoVideoCamera);
 if (view != null)
 {
-   view.IsEnabled = true;
+    view.IsEnabled = true;
 }
 ```
 


### PR DESCRIPTION
The enum name is [`HolographicViewConfigurationKind`](https://docs.microsoft.com/en-us/uwp/api/windows.graphics.holographic.holographicviewconfiguration?view=winrt-19041), but the code sample had it just as `HolographicViewConfiguration`.