### PR TITLE
Add missing directory to UX directory structure

### DIFF
--- a/mixed-reality-docs/mr-learning-base-06.md
+++ b/mixed-reality-docs/mr-learning-base-06.md
@@ -80,7 +80,7 @@ and the **Explode** button to toggle the exploded view on and off:
 
 ## Creating a dynamic menu that follows the user
 
-In the Project window, navigate to the **Assets** > **MRTK** > **SDK** > **UX** > **Prefabs** > **Menus** folder, click-and-drag the **NearMenu4x1** prefab into the Hierarchy window, set its Transform **Position** to X = 0, Y = -0.4, Z = 0 and configure it as follows:
+In the Project window, navigate to the **Assets** > **MRTK** > **SDK** > **Features** > **UX** > **Prefabs** > **Menus** folder, click-and-drag the **NearMenu4x1** prefab into the Hierarchy window, set its Transform **Position** to X = 0, Y = -0.4, Z = 0 and configure it as follows:
 
 * Verify that the **SolverHandler** component's **Tracked Target Type** is set to **Head**
 * Check the checkbox next to the **RadialView** Solver component so it is enabled by default


### PR DESCRIPTION
In the section [Creating a dynamic menu that follows the user](https://docs.microsoft.com/en-us/windows/mixed-reality/mr-learning-base-06#creating-a-dynamic-menu-that-follows-the-user), there is a missing directory in the folder hierarchy to reach the menu prefabs (when using the assets in Unity), namely **Features**. I have updated the folder structure to include this. 

Currently the documentation reads as:

Assets -> MRTK -> SDK -> UX -> Prefabs -> Menus

But should read as:

Assets -> MRTK -> SDK -> Features -> UX -> Prefabs -> Menus