### PR TITLE
docs: Incorrect resolution HL2 profile HQV 100

### DIFF
--- a/mixed-reality-docs/locatable-camera.md
+++ b/mixed-reality-docs/locatable-camera.md
@@ -38,7 +38,7 @@ HoloLens includes a world-facing camera mounted on the front of the device, whic
   
   | Profile                                         | Video     | Preview   | Still     | Frame rates | Horizontal Field of View (H-FOV) | Suggested usage                             |
   |-------------------------------------------------|-----------|-----------|-----------|-------------|----------------------------------|---------------------------------------------|
-  | Legacy,0  BalancedVideoAndPhoto,100             | 2272x1278 | 2272x1278 |           | 15,30       | 64.69                            | High quality video recording                |
+  | Legacy,0  BalancedVideoAndPhoto,100             | 2284x1284 | 2284x1284 |           | 15,30       | 64.69                            | High quality video recording                |
   | Legacy,0  BalancedVideoAndPhoto,100             | 896x504   | 896x504   |           | 15,30       | 64.69                            | Preview stream for high quality photo capture |
   | Legacy,0  BalancedVideoAndPhoto,100             |           |           | 3904x2196 |             | 64.69                            | High quality photo capture                  |
   | BalancedVideoAndPhoto,120                       | 1952x1100 | 1952x1100 | 1952x1100 | 15,30       | 64.69                            | Long duration scenarios                     |


### PR DESCRIPTION
When working on HoloLens 2 during debugging, the default width and height of the image for video stream on profile 'Legacy,0 BalancedVideoAndPhoto,100' is given as:

* Width - 2284
* Height - 1284

The documentation lists this as:

* Width - 2272
* Height - 1278

I am assuming this is a typo in the documentation, and that the correct value is being provided by the HoloLens 2. If not, I can close this pull request and raise as an Issue instead (if the error in the returned resolution is on the HoloLens 2 side).

For reference, the following code was used to obtain the resolution from the HoloLens 2 during debug:

```
var allCameras = await DeviceInformation.FindAllAsync(DeviceClass.VideoCapture);
var selectedCamera = allCameras.FirstOrDefault(c => c.EnclosureLocation?.Panel == Panel.Back) ?? allCameras.FirstOrDefault();

IReadOnlyList<MediaCaptureVideoProfile> profiles = MediaCapture.FindAllVideoProfiles(selectedCamera.Id);
foreach (var profile in profiles)
    {
        Debug.Log("Profile id is: " + profile.Id);
        var desc = profile.SupportedPhotoMediaDescription;
        foreach(var description in desc)
        {
            Debug.Log("Width is: " + description.Width);
            Debug.Log("Height is: " + description.Height);
        }
    }
```

Returned profile information as follows:

```
Profile id is: {6B52B017-42C7-4A21-BFE3-23F009149887},110
Width is: 2284
Height is: 1284
```