### PR TITLE
Fix broken link to MR-WebRTC repository

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/toc.yml
+++ b/mixed-reality-docs/mr-dev-docs/develop/toc.yml
@@ -361,7 +361,7 @@
         - name: Spectator view
           href: platform-capabilities-and-apis/spectator-view.md 
         - name: WebRTC 
-          href: https://github.com/microsoft/MixedReality-WebRTC.md 
+          href: https://github.com/microsoft/MixedReality-WebRTC 
     - name: Camera and capture  
       items: 
         - name: Locatable camera 


### PR DESCRIPTION
In the table of contents of the develop documentation, under the "Shared experiences in Mixed Reality" section, the link to the MixedReality-WebRTC was broken leading the user into a 404 page on GitHub.