### PR TITLE
Add missing Development Checkpoint section

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/unity/hand-eye-in-unit.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/unity/hand-eye-in-unit.md
@@ -41,6 +41,20 @@ You can find  other example scenes in [Mixed Reality Toolkit GitHub](https://git
 
 [![Example Scene](images/MRTK_Examples.png)](https://microsoft.github.io/MixedRealityToolkit-Unity/Documentation/README_HandInteractionExamples.html)
 
+## Next Development Checkpoint
+
+If you're following the Unity development checkpoint journey we've laid out, you're in the midst of exploring the MRTK core building blocks. From here, you can proceed to the next building block:
+
+> [!div class="nextstepaction"]
+> [Spatial Mapping](spatial-mapping-in-unity.md)
+
+Or jump to Mixed Reality platform capabilities and APIs:
+
+> [!div class="nextstepaction"]
+> [Shared experiences](shared-experiences-in-unity.md)
+
+You can always go back to the [Unity development checkpoints](unity-development-overview.md#2-core-building-blocks) at any time.
+
 ## See also
 
 * [Eye-based interaction](../../design/eye-gaze-interaction.md)


### PR DESCRIPTION
Hand eye tracking in Unity page was missing the "Next Development Checkpoint" section at the end of the page that allows the user to quickly jump into the next one.