### PR TITLE
Told user how to find the MRTK confugration menu

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/unity/tutorials/mr-learning-base-02.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/unity/tutorials/mr-learning-base-02.md
@@ -139,7 +139,7 @@ In the Project Settings window, select **Player** > **XR Settings**, click the *
 
 ![Unity XR Settings with add Windows Mixed Reality SDK selected](images/mr-learning-base/base-02-section5-step2-4.png)
 
-After Unity has finished importing the Windows Mixed Reality SDK, the MRTK Project Configurator window should appear again. If it doesn't, use the Unity menu to open it.
+After Unity has finished importing the Windows Mixed Reality SDK, the MRTK Project Configurator window should appear again. If it doesn't, you can manually open it from the Unity menu by going to **Mixed Reality Toolkit** > **Utilities** > **Configure Unity Project**
 
 In the MRTK Project Configurator window, use the **Audio spatializer** dropdown to select the **MS HRTF Spatializer**, then click the **Apply** button to apply the setting:
 


### PR DESCRIPTION
But note there's a problem - if this menu is not open, the options for "Audio Spatializer" dropdown  (discussed in the text below where I made the edit) will not be available for changing. Please update these documentations to tell the user how to get to that dropdown. I don't know how to do that.