### PR TITLE
Fix using directive

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/unity/locatable-camera-in-unity.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/unity/locatable-camera-in-unity.md
@@ -22,7 +22,9 @@ Only a single operation can occur with the camera at a time. You can check with 
 
 ## Photo Capture
 
-**Namespace:** *UnityEngine.XR.WSA.WebCam*<br>
+**Namespace:**  
+*UnityEngine.XR.WSA.WebCam(Unity \~2018)  
+UnityEngine.Windows.WebCam(Unity 2019\~)*<br>
 **Type:** *PhotoCapture*
 
 The *PhotoCapture* type allows you to take still photographs with the Photo Video Camera. The general pattern for using *PhotoCapture* to take a photo is as follows:


### PR DESCRIPTION
`UnityEngine.XR.WSA.WebCam` exists in Unity 2018, but does not exist in Unity 2019 or later.
`UnityEngine.Windows.WebCam` can be used in Unity 2019 or later.  
Reference:  
https://docs.unity3d.com/2018.4/Documentation/ScriptReference/XR.WSA.WebCam.PhotoCapture.html  
https://docs.unity3d.com/2019.4/Documentation/ScriptReference/Windows.WebCam.PhotoCapture.html  
