### PR TITLE
Fix broken link in ASA tutorial docs

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/unity/tutorials/mr-learning-asa-02.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/unity/tutorials/mr-learning-asa-02.md
@@ -144,7 +144,7 @@ In the Hierarchy window, select the **ParentAnchor** object, then in the Inspect
 Azure Spatial Anchors can not run in Unity, so to test the Azure Spatial Anchors functionality, you need to build the project and deploy the app to your device.
 
 > [!TIP]
-> For a reminder on how to build and deploy your Unity project to HoloLens 2, you can refer to the [Building your application to your HoloLens 2]((mr-learning-base-02.md#building-your-application-to-your-hololens-2) instructions.
+> For a reminder on how to build and deploy your Unity project to HoloLens 2, you can refer to the [Building your application to your HoloLens 2](mr-learning-base-02.md#building-your-application-to-your-hololens-2) instructions.
 
 When the app runs on your device, follow the on-screen instructions displayed on the Azure Spatial Anchor Tutorial Instructions panel:
 


### PR DESCRIPTION
Remove additional '(' character that was preventing the correct rendering of the markdown link.