### PR TITLE
Correct default oculus profile in docs

### DIFF
--- a/mrtk-unity/features/cross-platform/oculus-quest-mrtk.md
+++ b/mrtk-unity/features/cross-platform/oculus-quest-mrtk.md
@@ -61,7 +61,7 @@ to "Controllers and Hands".
 
 1. Configure your profile to use the **Oculus XR SDK Data Provider**
     - If not intending to modify the configuration profiles
-        - Change your profile to DefaultXRSDKInputSystemProfile and go to [Build and deploy your project to Oculus Quest](oculus-quest-mrtk.md#build-and-deploy-your-project-to-oculus-quest)
+        - Change your profile to DefaultMixedRealityToolkitConfigurationProfile and go to [Build and deploy your project to Oculus Quest](oculus-quest-mrtk.md#build-and-deploy-your-project-to-oculus-quest)
 
     - Otherwise follow the following:
         - Select the MixedRealityToolkit game object in the hierarchy and select **Copy and Customize** to clone the default mixed reality profile.


### PR DESCRIPTION
The current docs recommend setting your profile to `DefaultXRSDKInputSystemProfile`, however this is an input system profile, not a configuration profile, and cannot be selected without choosing Copy & Customize.

![image](https://user-images.githubusercontent.com/10459772/113325573-43092580-92de-11eb-9321-83b3d8532fd1.png)
