### PR TITLE
Use better default profile for oculus

### DIFF
--- a/mrtk-unity/features/cross-platform/oculus-quest-mrtk.md
+++ b/mrtk-unity/features/cross-platform/oculus-quest-mrtk.md
@@ -61,7 +61,7 @@ to "Controllers and Hands".
 
 1. Configure your profile to use the **Oculus XR SDK Data Provider**
     - If not intending to modify the configuration profiles
-        - Change your profile to DefaultMixedRealityToolkitConfigurationProfile and go to [Build and deploy your project to Oculus Quest](oculus-quest-mrtk.md#build-and-deploy-your-project-to-oculus-quest)
+        - Change your profile to DefaultXRSDKConfigurationProfile and go to [Build and deploy your project to Oculus Quest](oculus-quest-mrtk.md#build-and-deploy-your-project-to-oculus-quest)
 
     - Otherwise follow the following:
         - Select the MixedRealityToolkit game object in the hierarchy and select **Copy and Customize** to clone the default mixed reality profile.


### PR DESCRIPTION
I know that I just updated this a few hours ago. I chose that profile based on the screenshots the docs have where it shows you to Copy & Customize the `DefaultMixedRealityToolkitConfigurationProfile` However, I actually took some time to test this profile out and it would be better to actually use `DefaultXRSDKConfigurationProfile`.

If you use the other one, it will still build but Oculus head tracking won't work correctly. 