### PR TITLE
Clarify steps to enable remote deployment from Visual Studio

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
@@ -32,8 +32,8 @@ Start by enabling **Developer Mode** on your device, so Visual Studio can connec
 3. Select the **Settings** tile to launch the app in your environment.
 4. Select the **Update** menu item.
 5. Select the **For developers** menu item.
-6. Enable **Developer Mode** to deploy apps from Visual Studio to your HoloLens.
-7. Optional: Scroll down and also enable **Device Portal**, which lets you connect to the [Windows Device Portal](using-the-windows-device-portal.md) on your HoloLens from a web browser.
+6. Enable **Use developer features** and **Device discovery** to deploy apps from Visual Studio to your HoloLens.
+8. Optional: Scroll down and also enable **Device Portal**, which lets you connect to the [Windows Device Portal](using-the-windows-device-portal.md) on your HoloLens from a web browser.
 
 ### Windows PC
 

--- a/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
@@ -33,7 +33,7 @@ Start by enabling **Developer Mode** on your device, so Visual Studio can connec
 4. Select the **Update** menu item.
 5. Select the **For developers** menu item.
 6. Enable **Use developer features** to deploy apps from Visual Studio to your HoloLens. If your device is running Windows Holographic version 21H1 or newer, also enable **Device discovery**.
-8. Optional: Scroll down and also enable **Device Portal**, which lets you connect to the [Windows Device Portal](using-the-windows-device-portal.md) on your HoloLens from a web browser.
+7. Optional: Scroll down and also enable **Device Portal**, which lets you connect to the [Windows Device Portal](using-the-windows-device-portal.md) on your HoloLens from a web browser.
 
 ### Windows PC
 

--- a/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/platform-capabilities-and-apis/using-visual-studio.md
@@ -32,7 +32,7 @@ Start by enabling **Developer Mode** on your device, so Visual Studio can connec
 3. Select the **Settings** tile to launch the app in your environment.
 4. Select the **Update** menu item.
 5. Select the **For developers** menu item.
-6. Enable **Use developer features** and **Device discovery** to deploy apps from Visual Studio to your HoloLens.
+6. Enable **Use developer features** to deploy apps from Visual Studio to your HoloLens. If your device is running Windows Holographic version 21H1 or newer, also enable **Device discovery**.
 8. Optional: Scroll down and also enable **Device Portal**, which lets you connect to the [Windows Device Portal](using-the-windows-device-portal.md) on your HoloLens from a web browser.
 
 ### Windows PC


### PR DESCRIPTION
Deploying to a HoloLens from Visual Studio will fail with obscure errors unless the **Device discovery** option is enabled on the HoloLens, in addition to "developer mode" (i.e. **Use developer features**).