### PR TITLE
Fix Broken Link in WebXR Javascript Piano Tutorial

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/keyboard-interaction-03.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/keyboard-interaction-03.md
@@ -166,7 +166,7 @@ const createScene = async function(engine) {
     keyboard.parent = piano;
 
     // Import and scale piano frame
-    BABYLON.SceneLoader.ImportMesh("frame", "https://docs.microsoft.com/windows/mixed-reality/develop/javascript/tutorials/babylonjs-webxr-piano/files", "pianoFrame.babylon", scene, function(meshes) {
+    BABYLON.SceneLoader.ImportMesh("frame", "https://raw.githubusercontent.com/MicrosoftDocs/mixed-reality/docs/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/files/", "pianoFrame.babylon", scene, function(meshes) {
         const frame = meshes[0];
         frame.parent = piano;
     });
@@ -553,7 +553,7 @@ const createScene = async function(engine) {
     keyboard.parent = piano;
 
     // Import and scale piano frame
-    BABYLON.SceneLoader.ImportMesh("frame", "https://docs.microsoft.com/windows/mixed-reality/develop/javascript/tutorials/babylonjs-webxr-piano/files", "pianoFrame.babylon", scene, function(meshes) {
+    BABYLON.SceneLoader.ImportMesh("frame", "https://raw.githubusercontent.com/MicrosoftDocs/mixed-reality/docs/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/files/", "pianoFrame.babylon", scene, function(meshes) {
         const frame = meshes[0];
         frame.parent = piano;
     });

--- a/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/keyboard-model-02.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/keyboard-model-02.md
@@ -463,7 +463,7 @@ In this section, let's expand the usage of the key-creation functions to generat
     keyboard.parent = piano;
 
     // Import and scale piano frame
-    BABYLON.SceneLoader.ImportMesh("frame", "https://docs.microsoft.com/windows/mixed-reality/develop/javascript/tutorials/babylonjs-webxr-piano/files", "pianoFrame.babylon", scene, function(meshes) {
+    BABYLON.SceneLoader.ImportMesh("frame", "https://raw.githubusercontent.com/MicrosoftDocs/mixed-reality/docs/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/files/", "pianoFrame.babylon", scene, function(meshes) {
         const frame = meshes[0];
         frame.parent = piano;
     });
@@ -590,7 +590,7 @@ In this section, let's expand the usage of the key-creation functions to generat
         keyboard.parent = piano;
     
         // Import and scale piano frame
-        BABYLON.SceneLoader.ImportMesh("frame", "https://docs.microsoft.com/windows/mixed-reality/develop/javascript/tutorials/babylonjs-webxr-piano/files", "pianoFrame.babylon", scene, function(meshes) {
+        BABYLON.SceneLoader.ImportMesh("frame", "https://raw.githubusercontent.com/MicrosoftDocs/mixed-reality/docs/mixed-reality-docs/mr-dev-docs/develop/javascript/tutorials/babylonjs-webxr-piano/files/", "pianoFrame.babylon", scene, function(meshes) {
             const frame = meshes[0];
             frame.parent = piano;
         });


### PR DESCRIPTION
As pointed out in #454, babylon.js fails to import a mesh from the current link provided in the tutorial. The response returned from the current link does not fulfill babylon.js's CORS requirements.

This PR resolves the issue by updating the link to point to the file in this repository using [https://raw.githubusercontent.com](https://raw.githubusercontent.com) as described in the [babylon.js official documentation](https://doc.babylonjs.com/toolsAndResources/tools/playground/externalPGAssets#from-githubcom).