### PR TITLE
Fixed dead link

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/design/gaze-and-commit-eyes.md
+++ b/mixed-reality-docs/mr-dev-docs/design/gaze-and-commit-eyes.md
@@ -66,8 +66,8 @@ Either make your users aware they may need to keep looking at a target until the
 
 ## See also
 
-* [Eye-based interaction] (eye-gaze-interaction.md)
-* [Eye tracking on HoloLens 2] (eye-tracking.md)
+* [Eye-based interaction](eye-gaze-interaction.md)
+* [Eye tracking on HoloLens 2](eye-tracking.md)
 * [Gaze and commit](gaze-and-commit.md)
 * [Gaze and dwell](gaze-and-dwell.md)
 * [Hands - Direct manipulation](direct-manipulation.md)


### PR DESCRIPTION
Links aren't generated because a space is after a bracket.

In the Eye-gaze and commit page:
https://docs.microsoft.com/en-us/windows/mixed-reality/design/gaze-and-commit-eyes#see-also

<img width="1356" alt="Screen Shot 2021-11-28 at 21 06 31" src="https://user-images.githubusercontent.com/359823/143766995-8bee3545-7564-4ad8-8aba-70be666fd8f4.png">
