### PR TITLE
Adjust trivially incorrect mentions of "Windows Mixed Reality home"

### DIFF
--- a/enthusiast-guide/your-mixed-reality-home.md
+++ b/enthusiast-guide/your-mixed-reality-home.md
@@ -1,17 +1,17 @@
 ---
-title: Your mixed reality home
-description: How to navigate and teleport within the Windows Mixed Reality home, launch apps and games, personalize the home, and change visual, audio, and speech settings.
+title: Your Mixed Reality home
+description: How to navigate and teleport within the Mixed Reality home, launch apps and games, personalize the home, and change visual, audio, and speech settings.
 ms.topic: article
 keywords: Windows Mixed Reality, Mixed Reality, Virtual Reality, VR, MR, Home, Navigate, Get around, apps, games
 ---
 
-# Your Windows Mixed Reality home
+# Your Mixed Reality home
 
-## What is the Windows Mixed Reality home
+## What is the Mixed Reality home
 
 Windows Mixed Reality is the first spatial operating system. Instead of using a flat screen and a 2D interface, it uses our instinctual ability to navigate three-dimensional space. Every place has a purpose, and content has context. Just as your PC starts at the desktop interface and your phone begins with a home screen, Windows Mixed Reality starts at the Mixed Reality home. It's an environment that you can navigate and personalize to make your own. It's the canvas for the thousands of apps available in the Microsoft Store or SteamVR. You can multitask with these apps like never before--in 3D where space is almost limitless.
 
-## Move through the Windows Mixed Reality home
+## Move through the Mixed Reality home
 
 * **Physically walking:** If you've setup your headset with a room boundary and have cleared available space to walk around safely, you can take physical steps to move short distances in your home. One step in the real world is approximately a step in the virtual experience.
 * **Teleporting (using motion controllers):** You can quickly jump to a location by teleporting. Using the motion controllers, you can teleport by pushing the right or left thumbstick forward, aiming towards the direction you want to go, and then releasing the thumbstick.
@@ -23,7 +23,7 @@ Windows Mixed Reality is the first spatial operating system. Instead of using a 
 
 ## Launch an app
 
-1. From your Windows Mixed Reality home, press the Windows button on your controller to launch the Start menu.
+1. From your Mixed Reality home, press the Windows button on your controller to launch the Start menu.
 2. Select the app you wish to launch.
 3. Place the app where you would like to use it, and it will launch.
 4. From now on, you can click on the 3D model to launch the app.
@@ -44,11 +44,11 @@ Windows Mixed Reality is the first spatial operating system. Instead of using a 
 2. Launch Microsoft Store.
 3. Browse for an app or game you want, and then select "Get" or "Buy."
 
-You can also use the "New for you" app to browse for content, which appears as a shopping bag in your Windows Mixed Reality home.
+You can also use the "New for you" app to browse for content, which appears as a shopping bag in your Mixed Reality home.
 
 ## What is the "New for you" app
 
-You may notice that there's a Microsoft Store bag in your Windows Mixed Reality home. Clicking it will show your new and exciting apps that you can download or purchase.
+You may notice that there's a Microsoft Store bag in your Mixed Reality home. Clicking it will show your new and exciting apps that you can download or purchase.
 
 ## Personalize my home
 
@@ -63,23 +63,23 @@ Go to **Settings > Mixed Reality > Environment > Reset my home** ![Windows Setti
 ## Uninstall Windows Mixed Reality
 
 1. Unplug your headset
-2. Close Windows Mixed Reality Portal
-3. Go to **Settings > Mixed Reality > Uninstall > Uninstall** ![Windows Settings panel to uninstall mixed reality](images/1050px-uninstall2.png)
+2. Close Windows Mixed Reality Port
+3. Go to **Settings > Mixed Reality > Uninstall > Uninstall** ![Windows Settings panel to uninstall Windows Mixed Reality](images/1050px-uninstall2.png)
 
 ## Turn off the boundary
 
 Go to Mixed Reality Portal and open the menu in the upper left of the screen. Select **Run Set up > Room Boundary**. Switch the toggle to OFF. You should remain seated at your desk if you turn off the boundary.
 
-## Spatial sound in the Windows Mixed Reality home
+## Spatial sound in the Mixed Reality home
 
-The Windows Mixed Reality home includes a spatial sound simulation where sound from each app come from the location of the app. As you turn around, or move closer or farther to the app, the sound direction, and volume will change, just like in real life. 
+The Mixed Reality home includes a spatial sound simulation where sound from each app come from the location of the app. As you turn around, or move closer or farther to the app, the sound direction, and volume will change, just like in real life. 
 
 > [!NOTE]
 > This feature is disabled on PCs with integrated graphics due to the load placed on the GPU.
 
 ## See also
 
-* [Troubleshooting the Windows Mixed Reality home](wmr-setup-faq.yml#my-motion-controllers-aren-t-working)
+* [Troubleshooting the Mixed Reality home](wmr-setup-faq.yml#my-motion-controllers-aren-t-working)
 * [Using games and apps in Windows Mixed Reality](using-games-and-apps-in-windows-mixed-reality.md)
 * [How inside-out tracking works](tracking-system.md)
 * [How motion controllers work](controllers-in-wmr.md)


### PR DESCRIPTION
"Windows Mixed Reality home" replaced with its correct naming "Mixed Reality home" which seems to be the correct terminology? Changed a mention of "Mixed Reality" to "Windows Mixed Reality" to reflect a reference to the software instead of the platform. These adjustments may be trivial, please tell me what you think of them.