### PR TITLE
Typride reduce unnecessary links

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/index.yml
+++ b/mixed-reality-docs/mr-dev-docs/index.yml
@@ -122,13 +122,10 @@ conceptualContent:
       links:
         - url: develop/unity/unity-development-overview.md
           itemType: overview
-          text: Unity development overview
+          text: Unity docs - Overview
         - url: /windows/mixed-reality/mrtk-unity/
           itemType: overview
-          text: What is MRTK?
-        - url: /learn/paths/beginner-hololens-2-tutorials/
-          itemType: tutorial
-          text: HoloLens 2 tutorial series
+          text: MRTK for Unity
         - url: develop/unity/shared-experiences-in-unity.md
           itemType: concept
           text: Platform capabilities and APIs
@@ -146,16 +143,13 @@ conceptualContent:
       links:
         - url: develop/unreal/unreal-development-overview.md
           itemType: overview
-          text: Unreal development overview
-        - url: develop/unreal/tutorials/unreal-uxt-ch1.md
-          itemType: tutorial
-          text: Build a chess app tutorial series
+          text: Unreal docs - Overview
+        - url: /develop/unreal/unreal-mrtk-introduction.md
+          itemType: overview
+          text: MRTK for Unreal
         - url: develop/unreal/unreal-hololens-camera.md
           itemType: concept
           text: Platform capabilities and APIs
-        - url: develop/unreal/performance-recommendations-for-unreal.md
-          itemType: concept
-          text: Performance recommendations
         - url: develop/unreal/unreal-deploying.md
           itemType: deploy
           text: Deploying to device or emulator
@@ -170,7 +164,7 @@ conceptualContent:
       links:
         - url: develop/native/directx-development-overview.md
           itemType: overview
-          text: Native development overview
+          text: Native docs - Overview
         - url: develop/native/openxr.md
           itemType: overview
           text: What is OpenXR?
@@ -180,9 +174,6 @@ conceptualContent:
         - url: develop/native/openxr-best-practices.md
           itemType: concept
           text: OpenXR best practices
-        - url: develop/native/openxr-troubleshooting.md
-          itemType: reference
-          text: OpenXR troubleshooting
       # footerLink (optional)
       footerLink:
         url: develop/native/directx-development-overview.md

--- a/mixed-reality-docs/mr-dev-docs/index.yml
+++ b/mixed-reality-docs/mr-dev-docs/index.yml
@@ -129,9 +129,6 @@ conceptualContent:
         - url: /learn/paths/beginner-hololens-2-tutorials/
           itemType: tutorial
           text: HoloLens 2 tutorial series
-        - url: /windows/mixed-reality/mrtk-unity/
-          itemType: concept
-          text: Core building blocks
         - url: develop/unity/shared-experiences-in-unity.md
           itemType: concept
           text: Platform capabilities and APIs
@@ -153,9 +150,6 @@ conceptualContent:
         - url: develop/unreal/tutorials/unreal-uxt-ch1.md
           itemType: tutorial
           text: Build a chess app tutorial series
-        - url: develop/unreal/unreal-gaze-input.md
-          itemType: concept
-          text: Core building blocks
         - url: develop/unreal/unreal-hololens-camera.md
           itemType: concept
           text: Platform capabilities and APIs
@@ -203,7 +197,7 @@ tools:
     - title: MRTK for Unity
       # imageSrc should be square in ratio with no whitespace
       imageSrc: images/Final_mrtk-small_logo.png
-      url: https://github.com/microsoft/MixedRealityToolkit-Unity
+      url: https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity
     # Card
     - title: MRTK for Unreal 
       imageSrc: images/Final_mrtk-small_logo.png


### PR DESCRIPTION
- Adjusted the Hub page. 
- Updated broken links. 
- Adjusted link text to clarify that users can get to the docs by clicking on overviews. 
- Created similar structure between Unity/Unreal to be easier to read and highlight fewer, high-value docs.