### PR TITLE
fix Mission AR link

### DIFF
--- a/mixed-reality-docs/mr-dev-docs/develop/includes/tabs-samples.md
+++ b/mixed-reality-docs/mr-dev-docs/develop/includes/tabs-samples.md
@@ -75,4 +75,4 @@ Our partners at Epic Games have released an excellent HoloLens 2 sample project 
 > [!NOTE]
 > This experience must be streamed from a high-end PC to the headset.
 
-* [Mission AR](https://docs.unrealengine.com/Resources/Showcases/MissionAR/index.html)
+* [Mission AR](https://docs.unrealengine.com/4.27/en-US/Resources/Showcases/MissionAR/)


### PR DESCRIPTION
The current link ([https://docs.unrealengine.com/5.0/en-US/engine-feature-examples-for-unreal-engine/MissionAR](https://docs.unrealengine.com/5.0/en-US/engine-feature-examples-for-unreal-engine/MissionAR)) goes to a 404. The page for Mission AR is currently available for Unreal Engine 4.27 documentation and not 5.0 documentation (which is where the current link points).