### PR TITLE
Update mrtk-standard-shader.md

### DIFF
--- a/mrtk-unity/mrtk2/features/rendering/mrtk-standard-shader.md
+++ b/mrtk-unity/mrtk2/features/rendering/mrtk-standard-shader.md
@@ -93,7 +93,7 @@ For static lighting, the shader will respect lightmaps built by Unity's [Lightma
 
 ## Lightweight Scriptable Render Pipeline support
 
-The MRTK contains an upgrade path to allow developers to utilize Unity's Lightweight Scriptable Render Pipeline (LWRP) with MRTK shaders. Tested in Unity 2019.1.1f1 and Lightweight RP 5.7.2 package. or instructions on getting started with the LWRP, see [this page](https://docs.unity3d.com/Packages/com.unity.render-pipelines.lightweight@5.10/manual/getting-started-with-lwrp.html).
+The MRTK contains an upgrade path to allow developers to utilize Unity's Lightweight Scriptable Render Pipeline (LWRP) with MRTK shaders. Tested in Unity 2019.1.1f1 and Lightweight RP 5.7.2 package. For instructions on getting started with the LWRP, see [this page](https://docs.unity3d.com/Packages/com.unity.render-pipelines.lightweight@5.10/manual/getting-started-with-lwrp.html).
 
 To perform the MRTK upgrade, select: **Mixed Reality Toolkit -> Utilities -> Upgrade MRTK Standard Shader for Lightweight Render Pipeline**
 


### PR DESCRIPTION
Under `## Lightweight Scriptable Render Pipeline support`, fixed sentence issue with 
`or instructions on getting started with the LWR` to 
`For instructions on getting started with the LWR`