### PR TITLE
Update speech.md

### DIFF
--- a/mrtk-unity/mrtk3-input/packages/input/speech.md
+++ b/mrtk-unity/mrtk3-input/packages/input/speech.md
@@ -12,24 +12,22 @@ keywords: Unity, HoloLens, HoloLens 2, Mixed Reality, development, MRTK3, speech
 
 ## Overview
 
-Speech input in MRTK is achieved by an implementation of  `PhraseRecognitionSubsystem`. By default, MRTK ships `WindowsPhraseRecognitionSubsystem`, which utilizes Unity's `KeywordRecognizer`. As in MRTK v2, this default implementation is only supported on Windows Editor, Standalone Windows, and UWP.
+Speech input in MRTK is achieved by an implementation of  `KeywordRecognitionSubsystem`. By default, MRTK ships `WindowsKeywordRecognitionSubsystem`, which utilizes Unity's `KeywordRecognizer`. As in MRTK v2, this default implementation is only supported on Windows Editor, Standalone Windows, and UWP.
 
 > [!NOTE]
 > This guide provides steps to enable the speech subsystem in a new MRTK project, assuming basic non-speech-related setup is already in place. If you're using our sample project, you may notice that some steps have been performed for you.
 
-> [!IMPORTANT]
-> There's an external bug causing the "select" keyword to fail to be recognized when `WindowsPhraseRecognitionSubsystem` runs on HoloLens 2. We're working with relevant parties to address the issue. To mitigate, please change the speech recognition keyword under `StatefulInteractable` (or its subclass such as `PressableButton`) **-> Advanced StatefulInteractable Settings -> Allow Select By Voice -> Speech Recognition Keyword**.
 
 ## Setup
 
 ### Enable the speech subsystem
 
 1. Go to **Project Settings -> Mixed Reality Toolkit -> Available MRTK Subsystems**.
-2. Enable the speech subsystem you would like to use. At this time, MRTK only ships **WindowsPhraseRecognitionSubsystem**.
+2. Enable the speech subsystem you would like to use.
 
 ### Configure the profile correctly
 
-For certain subsystems, a profile is required in order for it to perform normally. The currently shipped `WindowsPhraseRecognitionSubsystem` doesn't require a profile, so you can skip this setup. Keep in mind that profiles may be needed by other future implementations of the `PhraseRecognitionSubsystem`.
+For certain subsystems, a profile is required in order for it to perform normally. The currently shipped `WindowsKeywordRecognitionSubsystem` doesn't require a profile, so you can skip this setup. Keep in mind that profiles may be needed by other future implementations of the `KeywordRecognitionSubsystem`.
 
 ### Ensure that the MRTK Speech GameObject is active
 


### PR DESCRIPTION
Removing the note that says the select keyword doesn't work on Hololens2.  The WindowsKeywordRecognitionSubsystem now correctly uses the required SelectKeywordRecognizer.