### PR TITLE
Updates dead Microsoft Store link to WMR Collection to next best equivalent

### DIFF
--- a/enthusiast-guide/index.yml
+++ b/enthusiast-guide/index.yml
@@ -79,9 +79,7 @@ productDirectory:
     # Card
     - title: What's new
       imageSrc: images/WMR_Docs_Landing_whats_new.png
-      links:
-        - url: https://www.microsoft.com/store/collections/mr-playgamesall
-          text: Windows Mixed Reality games
+      links:      
         - url: https://store.steampowered.com/search/?vrsupport=104
           text: New SteamVR releases 
         - url: webvr.md

--- a/enthusiast-guide/index.yml
+++ b/enthusiast-guide/index.yml
@@ -80,8 +80,8 @@ productDirectory:
     - title: What's new
       imageSrc: images/WMR_Docs_Landing_whats_new.png
       links:
-        - url: https://www.microsoft.com/store/collections/mixedreality
-          text: Best in Windows Mixed Reality
+        - url: https://www.microsoft.com/store/collections/mr-playgamesall
+          text: Windows Mixed Reality games
         - url: https://store.steampowered.com/search/?vrsupport=104
           text: New SteamVR releases 
         - url: webvr.md


### PR DESCRIPTION
The old URL has been removed, same with the ?gamecapabilities=VREnabled search filter in the Microsoft Store. https://www.microsoft.com/store/collections/mr-playgamesall is the only thing similar to still exist.